### PR TITLE
Pin runtime dependency opencv to 3.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   folder: isce2
 
 build:
-  number: 1
+  number: 2
   skip: True  # [win or py2k]
 
 requirements:
@@ -37,7 +37,7 @@ requirements:
     - scipy
     - hdf5
     - h5py
-    - opencv
+    - opencv 3.4
     - gdal
     - libgdal
     - fftw


### PR DESCRIPTION
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)

isce2 depends on the python "cv2" package. The default version for opencv is now 4.1. 